### PR TITLE
Fix GitHub Pages path from terragon-labs-site to rare-pupper

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://terragon-labs.github.io/rare-pupper",
+  "homepage": "https://roystbeef.github.io/rare-pupper",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://terragon-labs.github.io/terragon-labs-site",
+  "homepage": "https://terragon-labs.github.io/rare-pupper",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       '@': resolve(import.meta.dirname, './')
     }
   },
-  base: '/terragon-labs-site/',
+  base: '/rare-pupper/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- Updated `package.json` homepage URL to use `rare-pupper` repository path
- Updated `vite.config.ts` base path to match the new repository name
- Ensures built assets are accessible on GitHub Pages at the correct URL

## Test plan
- [x] Build completed successfully with new configuration
- [ ] Verify GitHub Pages deployment works with new path
- [ ] Test asset loading on deployed site

🤖 Generated with [Claude Code](https://claude.ai/code)