### PR TITLE
Remove rare-pupper base path and update image URLs to absolute

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -19,7 +19,7 @@ export function Hero() {
         >
           <div className="relative inline-block">
             <ImageWithFallback
-              src="/rare-pupper/images/profile.png"
+              src="https://rarepupper.com/images/profile.png"
               alt="Tortie the chihuahua-rat terrier mix"
               className="object-cover mx-auto border-8 border-white rounded-full shadow-2xl w-80 h-80"
             />

--- a/components/PhotoGallery.tsx
+++ b/components/PhotoGallery.tsx
@@ -4,32 +4,32 @@ import { ImageWithFallback } from './figma/ImageWithFallback';
 
 const photos = [
   {
-    src: '/rare-pupper/images/head-back.png',
+    src: 'https://rarepupper.com/images/head-back.png',
     caption: 'Professional head-tilting pose',
     hearts: 347,
   },
   {
-    src: '/rare-pupper/images/sleepy.png',
+    src: 'https://rarepupper.com/images/sleepy.png',
     caption: 'Tongue-out sleeping beauty',
     hearts: 892,
   },
   {
-    src: '/rare-pupper/images/pawing.png',
+    src: 'https://rarepupper.com/images/pawing.png',
     caption: 'String cheese appreciation moment',
     hearts: 1205,
   },
   {
-    src: '/rare-pupper/images/laundry.png',
+    src: 'https://rarepupper.com/images/laundry.png',
     caption: 'Blanket burrow headquarters',
     hearts: 654,
   },
   {
-    src: '/rare-pupper/images/tortugas.png',
+    src: 'https://rarepupper.com/images/tortugas.png',
     caption: 'Tortuga and the tortugas',
     hearts: 428,
   },
   {
-    src: '/rare-pupper/images/leafs.png',
+    src: 'https://rarepupper.com/images/leafs.png',
     caption: 'Leaf hunting expedition',
     hearts: 733,
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://roystbeef.github.io/rare-pupper",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       '@': resolve(import.meta.dirname, './')
     }
   },
-  base: '/rare-pupper/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- Removed the `/rare-pupper/` base path from the project configuration and assets
- Updated image URLs in components to use absolute URLs pointing to `https://rarepupper.com` instead of relative paths
- Removed the `homepage` field from `package.json` which referenced the old base path

## Changes

### Configuration
- Removed `base: '/rare-pupper/'` from `vite.config.ts` to stop using the subdirectory base path
- Deleted `homepage` field from `package.json` to reflect the removal of GitHub Pages deployment path

### Components
- **Hero.tsx**: Changed profile image source from relative path `/rare-pupper/images/profile.png` to absolute URL `https://rarepupper.com/images/profile.png`
- **PhotoGallery.tsx**: Updated all photo `src` fields from relative paths (e.g., `/rare-pupper/images/head-back.png`) to absolute URLs (e.g., `https://rarepupper.com/images/head-back.png`)

## Test plan
- [x] Verify that images load correctly from the new absolute URLs in both Hero and PhotoGallery components
- [x] Confirm the app works correctly without the base path configuration
- [x] Ensure no broken links or missing assets due to path changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f5a85179-162a-4d9f-9e88-9f00a75070d7