### PR TITLE
Update PawPrints size and opacity for subtle floating effect

### DIFF
--- a/components/PawPrints.tsx
+++ b/components/PawPrints.tsx
@@ -22,7 +22,7 @@ export function PawPrints() {
         y: Math.random() * 100,
         delay: Math.random() * 10,
         duration: 10 + Math.random() * 20,
-        size: 0.5 + Math.random() * 1
+        size: 1.0 + Math.random() * 2
       })
     }
     setPawPrints(prints)
@@ -33,7 +33,7 @@ export function PawPrints() {
       {pawPrints.map((print) => (
         <motion.div
           key={print.id}
-          className="absolute text-amber-200/30"
+          className="absolute text-amber-200/20"
           style={{
             left: `${print.x}%`,
             top: `${print.y}%`,
@@ -43,7 +43,7 @@ export function PawPrints() {
             y: [0, -20, 0],
             x: [0, 10, -10, 0],
             rotate: [0, 360],
-            opacity: [0.3, 0.6, 0.3]
+            opacity: [0.1, 0.3, 0.1]
           }}
           transition={{
             duration: print.duration,


### PR DESCRIPTION
## Summary
- Increased the size range of paw prints for better visibility
- Reduced the opacity of paw prints to create a more subtle floating effect

## Changes

### PawPrints Component
- Updated `size` property from `0.5 + Math.random() * 1` to `1.0 + Math.random() * 2` to make paw prints larger
- Changed CSS class opacity from `text-amber-200/30` to `text-amber-200/20` for lighter color
- Adjusted animation opacity keyframes from `[0.3, 0.6, 0.3]` to `[0.1, 0.3, 0.1]` to reduce visibility during animation

## Test plan
- [x] Verify paw prints appear larger on the screen
- [x] Confirm paw prints have a more subtle opacity effect
- [x] Check animation runs smoothly with updated opacity values

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9dbb0e50-ce5f-479e-b49d-d039f3c3984e