### PR TITLE
Enhance PawPrints component with reduced opacity for subtle effect

### DIFF
--- a/components/PawPrints.tsx
+++ b/components/PawPrints.tsx
@@ -33,7 +33,7 @@ export function PawPrints() {
       {pawPrints.map((print) => (
         <motion.div
           key={print.id}
-          className="absolute text-amber-200/20"
+          className="absolute text-amber-200/10"
           style={{
             left: `${print.x}%`,
             top: `${print.y}%`,
@@ -43,7 +43,7 @@ export function PawPrints() {
             y: [0, -20, 0],
             x: [0, 10, -10, 0],
             rotate: [0, 360],
-            opacity: [0.1, 0.3, 0.1]
+            opacity: [0.05, 0.15, 0.05]
           }}
           transition={{
             duration: print.duration,


### PR DESCRIPTION
## Summary
- Adjusts the opacity and color transparency of paw prints in the PawPrints component
- Makes paw prints more subtle and less visually intrusive by lowering opacity values

## Changes

### PawPrints Component
- Reduced the text color opacity from 20% to 10% (`text-amber-200/20` to `text-amber-200/10`)
- Lowered the animation opacity range from `[0.1, 0.3, 0.1]` to `[0.05, 0.15, 0.05]` for a gentler fade effect

## Test plan
- Verify paw prints render with the new lower opacity
- Confirm animation transitions smoothly with updated opacity values
- Ensure visual appearance is more subtle and blends better with the background

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/64f61152-1fb6-498c-9399-71b4437798cd