### PR TITLE
Update README: fix directory name and change license to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A delightful interactive website showcasing Tortie, a charismatic chihuahua-rat 
 1. Clone the repository:
 ```bash
 git clone <repository-url>
-cd terragon-labs-site
+cd isle-of-tortuga
 ```
 
 2. Install dependencies:
@@ -113,7 +113,7 @@ This will build the project and deploy it to the `gh-pages` branch.
 
 ## 📝 License
 
-This project is private and belongs to Terragon Labs.
+This project is open source and available under the MIT License.
 
 ---
 


### PR DESCRIPTION
## Summary
- Corrects the directory name in the README from `terragon-labs-site` to `isle-of-tortuga`
- Updates the license section to reflect that the project is open source under the MIT License instead of private

## Changes

### Documentation
- **README.md**:
  - Fixed the clone directory instruction to `cd isle-of-tortuga` for accuracy
  - Changed license statement from "This project is private and belongs to Terragon Labs." to "This project is open source and available under the MIT License."

## Test plan
- [x] Verified the directory name matches the actual project structure
- [x] Confirmed license text accurately reflects the open source status
- [x] Reviewed README formatting and clarity after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/982af950-7024-4a23-b85d-61d28e9275c6